### PR TITLE
Add create user

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e:watch": "jest --config ./test/jest-e2e.json --watch"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"
@@ -34,7 +35,7 @@
     "@prisma/client": "3.5.0",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.4.0",
-    "class-validator": "^0.13.1",
+    "class-validator": "^0.13.2",
     "dayjs": "^1.10.7",
     "joi": "^17.4.2",
     "passport": "^0.5.0",

--- a/src/common/utils/helpers.ts
+++ b/src/common/utils/helpers.ts
@@ -1,0 +1,1 @@
+export const getRandomString = () => Date.now().toString(36);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { useContainer } from 'class-validator';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -14,6 +15,7 @@ async function bootstrap() {
   console.log(`NODE_ENV: ${process.env.NODE_ENV}`);
   // enable useContainer to be able to inject into class validators
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(configService.get('PORT'));
 }
 bootstrap();

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,5 +1,14 @@
+import { IsEmail, IsNotEmpty } from "class-validator";
+
 export class CreateUserDto {
+  @IsEmail()
   email: string;
+
+  @IsNotEmpty()
   name: string;
+
+  @IsNotEmpty()
   password: string;
+
+  hash?: string;
 }

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -6,10 +6,40 @@ import { JwtStrategy } from '../common/strategies/jwt.strategy';
 import { PrismaService } from '../prisma.services';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { getRandomString } from '../common/utils/helpers';
 
 describe('UserController', () => {
   let userController: UserController;
   let userService: UserService;
+
+  const dto = {
+    name: 'John Doe',
+    email: 'john@example.com',
+    password: 'password',
+  };
+
+  const defaultExpectValues = {
+    id: expect.any(String),
+    email_confirmed: expect.any(Boolean),
+    is_admin: expect.any(Boolean),
+    is_deleted: expect.any(Boolean),
+    credentials_id: expect.any(Object),
+    created_at: expect.any(String),
+    updated_at: expect.any(String),
+  };
+
+  const mockUserService = {
+    create: jest.fn(({ hash, ...dto }) => ({
+      ...dto,
+      id: getRandomString(),
+      email_confirmed: false,
+      is_admin: false,
+      is_deleted: false,
+      updated_at: getRandomString(),
+      created_at: getRandomString(),
+      credentials_id: null,
+    })),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -25,7 +55,10 @@ describe('UserController', () => {
         }),
       ],
       providers: [UserService, PrismaService, JwtStrategy, ConfigService],
-    }).compile();
+    })
+      .overrideProvider(UserService)
+      .useValue(mockUserService)
+      .compile();
     userService = module.get<UserService>(UserService);
     userController = module.get<UserController>(UserController);
   });
@@ -33,5 +66,24 @@ describe('UserController', () => {
   it('should be defined', () => {
     expect(userController).toBeDefined();
     expect(userService).toBeDefined();
+  });
+
+  it('should create a user', async () => {
+    expect(await userController.create(dto)).toEqual({
+      ...dto,
+      ...defaultExpectValues,
+    });
+  });
+
+  it('should create a user with credentials', async () => {
+    expect(await userController.create({...dto, hash: "xyz"})).toEqual({
+      ...dto,
+      ...defaultExpectValues,
+    });
+  });
+
+  it('should call user service with appropriate dto data', async () => {
+    expect(await userController.create(dto));
+    expect(mockUserService.create).toHaveBeenCalledWith(dto);
   });
 });

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -5,9 +5,41 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JwtStrategy } from '../common/strategies/jwt.strategy';
 import { PrismaService } from '../prisma.services';
 import { UserService } from './user.service';
+import { getRandomString } from '../common/utils/helpers';
 
 describe('UserService', () => {
   let userService: UserService;
+
+  const dto = {
+    name: 'John Doe',
+    email: 'john@example.com',
+    password: 'password',
+  };
+
+  const defaultExpectValues = {
+    id: expect.any(String),
+    email_confirmed: expect.any(Boolean),
+    is_admin: expect.any(Boolean),
+    is_deleted: expect.any(Boolean),
+    credentials_id: expect.any(Object),
+    created_at: expect.any(String),
+    updated_at: expect.any(String),
+  };
+
+  const mockPrismaService = {
+    user: {
+      create: jest.fn(({ data: {credentials: { create: { hash }}, ...dto } }) => ({
+        id: getRandomString(),
+        ...dto,
+        email_confirmed: false,
+        is_admin: false,
+        is_deleted: false,
+        updated_at: getRandomString(),
+        created_at: getRandomString(),
+        credentials_id: null,
+      })),
+    },
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,11 +54,21 @@ describe('UserService', () => {
         }),
       ],
       providers: [UserService, PrismaService, JwtStrategy, ConfigService],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrismaService)
+      .compile();
     userService = module.get<UserService>(UserService);
   });
 
   it('should be defined', () => {
     expect(userService).toBeDefined();
+  });
+
+  it('should create user record and return it', async () => {
+    expect(await userService.create({ hash: 'xyz', ...dto })).toEqual({
+      ...defaultExpectValues,
+      ...dto,
+    });
   });
 });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
    * @returns User
    */
   async findUnique(whereUnique: Prisma.UserWhereUniqueInput, includeCredentials = false) {
-    return this.prisma.user.findUnique({ where: { ...whereUnique } });
+    return this.prisma.user.findUnique({ where: { ...whereUnique }, include: { credentials: true } });
   }
 
   /**
@@ -45,7 +45,10 @@ export class UserService {
    * @returns result of create
    */
   async create(createUserDto: CreateUserDto) {
-    return this.prisma.user.create({ data: createUserDto });
+    const { hash, ...rest } = createUserDto;
+    return hash
+      ? this.prisma.user.create({ data: { ...rest, credentials: { create: { hash } } } })
+      : this.prisma.user.create({ data: { ...rest } });
   }
 
   /**
@@ -69,7 +72,7 @@ export class UserService {
    * @returns results of users and credentials table modification
    */
   async delete(deleteUserDto: DeleteUserDto) {
-    return this.prisma.user.update({ where: { id: deleteUserDto.id }, data: { is_deleted: true }});
+    return this.prisma.user.update({ where: { id: deleteUserDto.id }, data: { is_deleted: true } });
   }
 
   /**

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,21 +1,167 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
+import { getRandomString } from '../src/common/utils/helpers';
+import { PrismaService } from '../src/prisma.services';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
+  const data = { email: 'example@example.com', name: 'John Snnow', password: 'password' };
+  const defaultResponseData = {
+    email_confirmed: false,
+    is_admin: false,
+    is_deleted: false,
+    updated_at: getRandomString(),
+    created_at: getRandomString(),
+    credentials_id: 'xyz',
+  };
+
+  const defaultUserExpectValues = {
+    id: expect.any(String),
+    email_confirmed: expect.any(Boolean),
+    is_admin: expect.any(Boolean),
+    is_deleted: expect.any(Boolean),
+    credentials_id: expect.any(String),
+    created_at: expect.any(String),
+    updated_at: expect.any(String),
+  };
+
+  const mockPrismaService = {
+    user: {
+      create: jest.fn().mockResolvedValue({
+        id: getRandomString(),
+        ...data,
+        ...defaultResponseData
+      }),
+      findMany: jest.fn().mockResolvedValue([{ id: getRandomString(), ...data, ...defaultResponseData }]),
+      findUnique: jest.fn().mockResolvedValue({}),
+      update: jest.fn().mockResolvedValue({}),
+      delete: jest.fn().mockResolvedValue({}),
+    },
+  };
+
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrismaService)
+      .compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
   it('/api/_health (GET)', () => {
     return request(app.getHttpServer()).get('/api/_health').expect(200).expect('OK');
   });
+
+  it('/user (GET)', async () => {
+    return request(app.getHttpServer())
+      .get('/user')
+      .expect(200)
+      .then((res) => {
+        expect(res.body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.any(String),
+              name: expect.any(String),
+              email: expect.any(String),
+              is_deleted: expect.any(Boolean),
+              ...defaultUserExpectValues,
+            }),
+          ]),
+        );
+      });
+  });
+
+  it('/user (POST) --> create a new user - without hash', async () => {
+    return request(app.getHttpServer())
+      .post('/user')
+      .send(data)
+      .expect(201)
+      .then((res) => {
+        expect(res.body).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            name: expect.any(String),
+            email: expect.any(String),
+            is_deleted: expect.any(Boolean),
+            ...defaultUserExpectValues,
+          }),
+        );
+      });
+  });
+
+  it('/user (POST) --> create a new user - with hash', async () => {
+    return request(app.getHttpServer())
+      .post('/user')
+      .send({...data, hash: 'xyz'})
+      .expect(201)
+      .then((res) => {
+        expect(res.body).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            name: expect.any(String),
+            email: expect.any(String),
+            is_deleted: expect.any(Boolean),
+            ...defaultUserExpectValues,
+          }),
+        );
+      });
+  });
+
+  it('/user (POST)--> return 400 validation error - incomplete dto ', async () => {
+    const {email, ...rest} = data;
+    return request(app.getHttpServer())
+      .post('/user')
+      .send(rest)
+      .expect(400)
+      .then((res) => {
+        expect(res.body).toEqual(
+          expect.objectContaining({
+            statusCode: expect.any(Number),
+            error: expect.any(String),
+            message: expect.arrayContaining([expect.any(String)]),
+          }),
+        );
+      });
+  });
+
+  it('/user (POST)--> return 400 validation error - invalid email ', async () => {
+    return request(app.getHttpServer())
+      .post('/user')
+      .send({...data, email: "me"})
+      .expect(400)
+      .then((res) => {
+        expect(res.body).toEqual(
+          expect.objectContaining({
+            statusCode: expect.any(Number),
+            error: expect.any(String),
+            message: expect.arrayContaining([expect.any(String)]),
+          }),
+        );
+      });
+  });
+
+  it('/user (POST)--> return 400 validation error - empty request body ', async () => {
+    return request(app.getHttpServer())
+      .post('/user')
+      .send({})
+      .expect(400)
+      .then((res) => {
+        expect(res.body).toEqual(
+          expect.objectContaining({
+            statusCode: expect.any(Number),
+            error: expect.any(String),
+            message: expect.arrayContaining([expect.any(String)]),
+          }),
+        );
+      });
+  });
+
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,11 +1059,6 @@
   dependencies:
     "@types/superagent" "*"
 
-"@types/validator@^13.1.3":
-  version "13.7.0"
-  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.0.tgz#fa25263656d234473025c2d48249a900053c355a"
-  integrity sha512-+jBxVvXVuggZOrm04NR8z+5+bgoW4VZyLzUO+hmPPW1mVFL/HaitLAkizfv4yg9TbG8lkfHWVMQ11yDqrVVCzA==
-
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
@@ -1750,14 +1745,13 @@ class-transformer@^0.4.0:
   resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.4.0.tgz#b52144117b423c516afb44cc1c76dbad31c2165b"
   integrity sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==
 
-class-validator@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.13.1.tgz#381b2001ee6b9e05afd133671fbdf760da7dec67"
-  integrity sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==
+class-validator@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
+  integrity sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==
   dependencies:
-    "@types/validator" "^13.1.3"
-    libphonenumber-js "^1.9.7"
-    validator "^13.5.2"
+    libphonenumber-js "^1.9.43"
+    validator "^13.7.0"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -3658,10 +3652,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libphonenumber-js@^1.9.7:
-  version "1.9.43"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.43.tgz#2371e4383e6780990381d5b900b8c22666221cbb"
-  integrity sha512-tNB87ZutAiAkl3DE/Bo0Mxqn/XZbNxhPg4v9bYBwQQW4dlhBGqXl1vtmPxeDWbrijzwOA9vRjOOFm5V9SK/W3w==
+libphonenumber-js@^1.9.43:
+  version "1.9.44"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz#d036364fe4c1e27205d1d283c7bf8fc25625200b"
+  integrity sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g==
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -5117,7 +5111,7 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-validator@^13.5.2:
+validator@^13.7.0:
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==


### PR DESCRIPTION
#### What does this MR do?
This MR adds create user implementation

#### Description of Task to be completed?
- install class-validator
- add global ValidationPipe
- add create user controller unit test
- add create user service unit test
- add create user e2e test
- modify create user service to accept hash
- modify create user dto to include hash

#### How should this be manually tested?
- Clone the repo
- Checkout to `ft-add-create-user`
- Install dependencies `yarn install`
- Run `npx prisma migrate dev --name init`
- Run `npx prisma db seed`
- Run `yarn start`
- Run e2e test 'yarn test:e2e`
- Run unit tests `yarn test`

#### Any background context you want to provide?
- Install nodejs
- Optionally install `yarn`

#### What are the relevant REDMI TRELLO issue?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
